### PR TITLE
Throw JsonFormatException when field should be an array but is an object

### DIFF
--- a/src/Internal/ArrayAdapter.php
+++ b/src/Internal/ArrayAdapter.php
@@ -33,6 +33,9 @@ class ArrayAdapter implements Adapter
     {
         $mapped_items = [];
         foreach ($items as $idx => $item) {
+            if (!is_int($idx)) {
+                throw new JsonFormatException('Expected array, found object', $path);
+            }
             $mapped_items[] = $delegate->mapDecoded($item, $this->type, $path->withArrayIndex($idx));
         }
         return $mapped_items;

--- a/test/Feature/StrictJsonTest.php
+++ b/test/Feature/StrictJsonTest.php
@@ -505,4 +505,15 @@ class StrictJsonTest extends TestCase
             $mapper->mapDecodedToArrayOf($decoded, Type::int(), JsonPath::root())
         );
     }
+
+    /**
+     * @throws JsonFormatException
+     */
+    public function testMapObjectToArray(): void
+    {
+        $mapper = new StrictJson();
+        $this->expectException(JsonFormatException::class);
+        $this->expectExceptionMessage('Expected array, found object');
+        $mapper->mapToArrayOf('{"one": 1, "two": 2}', Type::int());
+    }
 }


### PR DESCRIPTION
There was a bug that caused it to throw TypeError instead

Depending on your definition, this may be a breaking change. In the case
that you noticed this bug and caught TypeError but not
JsonFormatException, this would break your code. That seems incredibly
unlikely though, it seems far more likely that the harm of pushing this
change to a major version change is greater